### PR TITLE
Implement two processes to transfer, sell and burn DAO funds

### DIFF
--- a/.env-burn.example
+++ b/.env-burn.example
@@ -1,0 +1,7 @@
+PROCESS_TYPE=burn
+MULTISIG_ACCOUNT=moecki.burn
+ACCOUNT=moecki.burn
+POSTING_KEY=XXXX
+ACTIVE_KEY=XXXX
+MULTISIG_ACCOUNTS=moecki.burn moecki.signer1 moecki.signer2 moecki.signer3
+MARKET_MINUTE=11

--- a/.env-transfer.example
+++ b/.env-transfer.example
@@ -1,0 +1,8 @@
+PROCESS_TYPE=transfer
+MULTISIG_ACCOUNT=moecki.transfer
+ACCOUNT=moecki.transfer
+POSTING_KEY=XXXX
+ACTIVE_KEY=XXXX
+MULTISIG_ACCOUNTS=moecki.transfer moecki.signer1 moecki.signer2 moecki.signer3
+AMOUNT_SBD=0.001
+SEND_TO=moecki.burn

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 PROCESS_TYPE=transfer
-MULTISIG_ACCOUNT=funditionms
-ACCOUNT=funditionms1
+MULTISIG_ACCOUNT=moecki.multisig
+ACCOUNT=moecki.multisig
 POSTING_KEY=XXXX
 ACTIVE_KEY=XXXX
-MULTISIG_ACCOUNTS=funditionms funditionms1 funditionms2 funditionms3
+MULTISIG_ACCOUNTS=moecki.multisig moecki.signer1 moecki.signer2 moecki.signer3
 AMOUNT_SBD=0.001
-SEND_TO=future.witness
+SEND_TO=moecki
 MARKET_MINUTE=21

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ ACTIVE_KEY=XXXX
 MULTISIG_ACCOUNTS=funditionms funditionms1 funditionms2 funditionms3
 AMOUNT_SBD=0.001
 SEND_TO=future.witness
+MARKET_MINUTE=21

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-PROCESS_TYPE=transfer
-MULTISIG_ACCOUNT=moecki.multisig
-ACCOUNT=moecki.multisig
-POSTING_KEY=XXXX
-ACTIVE_KEY=XXXX
-MULTISIG_ACCOUNTS=moecki.multisig moecki.signer1 moecki.signer2 moecki.signer3
-AMOUNT_SBD=0.001
-SEND_TO=moecki
-MARKET_MINUTE=21

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+PROCESS_TYPE=transfer
 MULTISIG_ACCOUNT=funditionms
 ACCOUNT=funditionms1
 POSTING_KEY=XXXX

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.env*
+.env
 node_modules
 .devcontainer
 .vscode

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ This tool makes a chaining of signature to use the multisig feature on Steem to 
   
 ## Env file
 
+- PROCESS_TYPE=transfer #chain type (transfer or burn; transfer = transfer to market account or back to dao, burn = sell SBD and burn STEEM)
 - MULTISIG_ACCOUNT=funditionms #the multisig account
 - ACCOUNT=funditionms1 #current account (if in last position will trigger the transfer using the previous account tx stored in the json_metadata field)
 - POSTING_KEY=XXXX  #current account posting key (used to update the json_metadata field)
 - ACTIVE_KEY=XXXX  #current account active key (used to sign the transaction)
 - MULTISIG_ACCOUNTS=funditionms funditionms1 funditionms2 funditionms3  #list of accounts used for chaining
-- AMOUNT_SBD=0.001 #amount of SBD to send
-- SEND_TO=future.witness #to whom the funds should be send
+- AMOUNT_SBD=0.001 #amount of SBD to send (only used for type = transfer; remaining SBD will be transferred back to DAO)
+- SEND_TO=future.witness #to whom the funds should be send (only used for type = transfer)

--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ This tool makes a chaining of signature to use the multisig feature on Steem to 
 - MULTISIG_ACCOUNTS=funditionms funditionms1 funditionms2 funditionms3  #list of accounts used for chaining
 - AMOUNT_SBD=0.001 #amount of SBD to send (only used for type = transfer; remaining SBD will be transferred back to DAO)
 - SEND_TO=future.witness #to whom the funds should be send (only used for type = transfer)
+- MARKET_MINUTE=11 #minute of each hour in which SBD are sold (only used for type = burn)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,35 @@
 # SteemWitnesses MultiSig
 
-This tool makes a chaining of signature to use the multisig feature on Steem to transfer SBD from a multisign account. Another branch is available but it needs a fix to retrieve the same refs for blocks.
+This tool makes a chaining of signature to use the multisig feature on Steem.
+Available are two chaining processes:
+
+1. To transfer SBD from a multisign account (**transfer** process).
+2. To sell SBD on the internal market and burn the bought STEEM (**burn** process).
 
 ## How to use this code?
 
+### Using with Docker
+
+It is recommended to run the script in a Docker container.
+
+- Clone the Repo
+  
+- Create a .env file for each process with the required private keys. Explanation for the .env file below.
+
+  1. For **transfer** process create a file named `.env-transfer`
+  2. For **burn** process create a file named `.env-burn`
+  
+- Building the images
+  
+  `docker compose build`
+
+- Running the containers
+
+  `docker compose up -d`
+
 ### Using without Docker
+
+Without Docker only one process can started, because the process expects a file named `.env`.
 
 - Install dependencies
 
@@ -14,26 +39,25 @@ This tool makes a chaining of signature to use the multisig feature on Steem to 
 
 - Run `npm run start`
 
-### Using with Docker
-
-- Create a .env file with the required private keys. Explanation for the .env file below.
-  
-- Building an image
-  
-  `docker build -t ms_transfer_image .`
-
-- Running the container
-
-  `docker run -d --name ms_transfer ms_transfer_image`
-  
 ## Env file
 
-- PROCESS_TYPE=transfer #chain type (transfer or burn; transfer = transfer to market account or back to dao, burn = sell SBD and burn STEEM)
-- MULTISIG_ACCOUNT=funditionms #the multisig account
-- ACCOUNT=funditionms1 #current account (if in last position will trigger the transfer using the previous account tx stored in the json_metadata field)
-- POSTING_KEY=XXXX  #current account posting key (used to update the json_metadata field)
-- ACTIVE_KEY=XXXX  #current account active key (used to sign the transaction)
-- MULTISIG_ACCOUNTS=funditionms funditionms1 funditionms2 funditionms3  #list of accounts used for chaining
-- AMOUNT_SBD=0.001 #amount of SBD to send (only used for type = transfer; remaining SBD will be transferred back to DAO)
-- SEND_TO=future.witness #to whom the funds should be send (only used for type = transfer)
-- MARKET_MINUTE=11 #minute of each hour in which SBD are sold (only used for type = burn)
+### transfer process
+
+- PROCESS_TYPE=transfer                 #chain type
+- MULTISIG_ACCOUNT=moecki.transfer      #the multisig account
+- ACCOUNT=moecki.signer1                #current account (if in last position will trigger the transfer using the previous account tx stored in the json_metadata field)
+- POSTING_KEY=XXXX                      #current account posting key (used to update the json_metadata field)
+- ACTIVE_KEY=XXXX                       #current account active key (used to sign the transaction)
+- MULTISIG_ACCOUNTS=moecki.multisig moecki.signer1 moecki.signer2 moecki.signer3                          #list of accounts used for chaining
+- AMOUNT_SBD=0.001                      #amount of SBD to send (remaining SBD will be transferred back to DAO)
+- SEND_TO=moecki.burn                   #to whom the funds should be send
+
+### burn process
+
+- PROCESS_TYPE=burn                     #chain type
+- MULTISIG_ACCOUNT=moecki.burn          #the multisig account
+- ACCOUNT=moecki.signer1                #current account (if in last position will trigger the transfer using the previous account tx stored in the json_metadata field)
+- POSTING_KEY=XXXX                      #current account posting key (used to update the json_metadata field)
+- ACTIVE_KEY=XXXX                       #current account active key (used to sign the transaction)
+- MULTISIG_ACCOUNTS=moecki.burn moecki.signer1 moecki.signer2 moecki.signer3                                 #list of accounts used for chaining
+- MARKET_MINUTE=11                      #minute of each hour in which SBD are sold (> 6)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  transfer:
+    build: .
+    volumes:
+      - ./.env-transfer:/usr/src/app/.env
+    container_name: transfer-process
+
+  burn:
+    build: .
+    volumes:
+      - ./.env-burn:/usr/src/app/.env
+    container_name: burn-process

--- a/start.js
+++ b/start.js
@@ -24,6 +24,7 @@ const context = {
     metadataKey
 };
 
+// check if processing should start based on the process type
 const shouldProcessStart = (currentTime) => {
     // start processing only once per hour
     if (currentTime.hour == lastHour) 
@@ -48,6 +49,7 @@ const shouldProcessStart = (currentTime) => {
     }
 };
 
+// main function to process transactions for multisig accounts defined in .env
 const processTransactions = async () => {
     const now = new Date();
     const currentTime = {

--- a/start.js
+++ b/start.js
@@ -34,16 +34,10 @@ const shouldProcessStart = (currentTime) => {
             // start processing 1 minute after the previous account
             return currentTime.minutes > accountIndex + 1;
         case 'burn':
-            // TODO for testing
-            // return true;
-            // ----------------
             // start processing at MARKET_MINUTE and after the previous account
             const marketMinute = parseInt(process.env.MARKET_MINUTE);
-            // TODO for testing
-            // const marketMinute = currentTime.minutes + (currentTime.minutes % 2 == 0 ? 0 : 1);
-            // ----------------
             const startSeconds = accountIndex * 15; // max 4 accounts in chain
-            const endSeconds = startSeconds + 11;
+            const endSeconds = startSeconds + 12;
             return currentTime.minutes == marketMinute && 
                 currentTime.seconds >= startSeconds && currentTime.seconds <= endSeconds;
     }

--- a/start.js
+++ b/start.js
@@ -25,7 +25,7 @@ const context = {
 };
 
 const shouldProcessStart = (currentHour, currentMinutes, currentSeconds) => {
-    // start processing once per hour
+    // start processing only once per hour
     if (currentHour == lastHour) 
         return false;
     switch (processType) {

--- a/start.js
+++ b/start.js
@@ -44,7 +44,7 @@ const shouldProcessStart = (currentTime) => {
             const startSeconds = accountIndex * 15; // max 4 accounts in chain
             const endSeconds = startSeconds + 11;
             return currentTime.minutes == marketMinute && 
-            currentTime.seconds >= startSeconds && currentTime.seconds <= endSeconds;
+                currentTime.seconds >= startSeconds && currentTime.seconds <= endSeconds;
     }
 };
 

--- a/utils.js
+++ b/utils.js
@@ -14,7 +14,6 @@ function getDynamicGlobalProperties() {
     });
 }
 
-
 function sendTransaction(transaction, privateKey) {
     return new Promise((resolve, reject) => {
         steem.broadcast.send(transaction, privateKey, (err, result) => {
@@ -51,10 +50,23 @@ function getAccount(account) {
     });
 }
 
-function transactionIsValid(transaction) {
-    return transaction[0][0] === 'transfer' &&
-    transaction[0][1].to === process.env.SEND_TO &&
-    transaction[0][1].amount === `${process.env.AMOUNT_SBD} SBD`;
+function transactionIsValid(operations) {
+    switch (process.env.PROCESS_TYPE) {
+        case 'transfer':
+            // max 2 operations allowed
+            // transfer to market account and transfer back to dao account
+            if (operations.length > 2) {
+                return false;
+            }
+            // allowed are only transfer operations
+            // and to accounts specified in allowedAccounts
+            //const allowedAccounts = [process.env.SEND_TO, "steem.dao"];
+            const allowedAccounts = [process.env.SEND_TO, "moecki.tests"]; // for testing
+            return operations.every(operation => 
+                operation[0] === 'transfer' &&
+                allowedAccounts.includes(operation[1].to)
+            );
+    }
 }
 
 function transactionIsExpired(transaction) {
@@ -77,27 +89,36 @@ async function getJsonMetadata(accountName) {
     return json_metadata;
 }
 
+async function getBalance(accountName, unit) {
+    const [account] = await getAccount(accountName)
+
+    const key = unit === 'STEEM' ? 'balance' : 'sbd_balance';
+    const balance = account[key].split(' ')[0]
+    
+    return parseFloat(balance);
+}
+
 async function getPreviousTransaction(context) {
-    const { accountIndex } = context;
+    const { accountIndex, metadataKey } = context;
     let previousAccountName = getPreviousAccountName(context);
     let previous_json_metadata = await getJsonMetadata(previousAccountName);
 
-    if (!previous_json_metadata.mtx) {
+    if (!previous_json_metadata[metadataKey]) {
         // console.log(`No transaction data found in '${previousAccountName}'`);
         throw new Error(`No transaction data found in '${previousAccountName}'`);
     }
 
-    let previousTx = JSON.parse(previous_json_metadata.mtx)
+    let previousTx = JSON.parse(previous_json_metadata[metadataKey])
 
     if (accountIndex > 1 && transactionIsExpired(previousTx)) {
         console.log(`Transaction from '${previousAccountName}' expired, get transaction from second last account`);
 
         previousAccountName = getPreviousAccountName({ ...context, accountIndex: accountIndex - 1 });
         previous_json_metadata = await getJsonMetadata(previousAccountName);
-        previousTx = JSON.parse(previous_json_metadata.mtx)
+        previousTx = JSON.parse(previous_json_metadata[metadataKey])
     }
 
-    if (!transactionIsValid(previousTx.operations)) {
+    if (!transactionIsValid(previousTx.operations, context)) {
         // console.log(`Transaction data from '${previousAccountName}' mismatch`);
         throw new Error(`Transaction data from '${previousAccountName}' mismatch`);
     }
@@ -110,78 +131,126 @@ async function getPreviousTransaction(context) {
     return previousTx;
 }
 
-function createPublishTx() {
+async function getBlankTransaction() {
+    const expireTime = 1000 * 3000;
+    const globalProps = await getDynamicGlobalProperties();
+    const ref_block_num = globalProps.head_block_number & 0xFFFF;
+    const ref_block_prefix = Buffer.from(globalProps.head_block_id, 'hex').readUInt32LE(4);
+
+    return {
+        ref_block_num,
+        ref_block_prefix,
+        expiration: new Date(Date.now() + expireTime).toISOString().slice(0, -5),
+        operations: [],
+        extensions: []
+    };
+}
+
+async function getOperations() {
+    switch (process.env.PROCESS_TYPE) {
+        case 'transfer':
+            let ops = [];
+            // transfer AMOUNT_SBD to market account
+            const sbd_balance = await getBalance(process.env.MULTISIG_ACCOUNT, 'SBD');
+            const to_market = Math.min(sbd_balance, parseFloat(process.env.AMOUNT_SBD));
+            ops.push(getTransferOperation(
+                to_market, 
+                'SBD', 
+                process.env.MULTISIG_ACCOUNT, 
+                process.env.SEND_TO,
+                'DAO amount for selling and burning')
+            )
+            // transfer remaining amounts back to dao
+            const to_dao = sbd_balance - to_market;
+            // ops.push(getTransferOperation(
+            //     to_dao, 
+            //     'SBD', 
+            //     process.env.MULTISIG_ACCOUNT, 
+            //     'steem.dao',
+            //     'DAO amount not used for selling and burning')
+            // )
+            ops.push(getTransferOperation(
+                0.001, 
+                'SBD', 
+                process.env.MULTISIG_ACCOUNT, 
+                'moecki.tests',
+                'DAO amount not used for selling and burning') // for testing
+            )
+            return ops;
+        case 'burn':
+    }
+}
+
+function getAccountUpdateOperation(accountName, posting_json_metadata) {
+    return ['account_update2',
+        {
+            'account': accountName,
+            'json_metadata': '',
+            'posting_json_metadata': posting_json_metadata
+        }
+    ];
+}
+
+function getTransferOperation(amount, unit, from, to, memo = '') {
+    return ['transfer',
+        {
+            'amount': amount + ' ' + unit.toUpperCase(),
+            'from': from,
+            'memo': memo,
+            'to': to
+        }
+    ];
+}
+
+function getOrderOperation(account, orderid, amount, unit) {
+}
+
+function createPublishTx(context) {
     return new Promise(async (resolve, reject) => {
+        
+        const { accountName, metadataKey } = context;
 
-        const username = process.env.ACCOUNT
-        const expireTime = 1000 * 3000;
-        const globalProps = await getDynamicGlobalProperties();
-        const ref_block_num = globalProps.head_block_number & 0xFFFF;
-        const ref_block_prefix = Buffer.from(globalProps.head_block_id, 'hex').readUInt32LE(4);
-
-        const transactionData = {
-            operations: [
-                ['transfer',
-                    {
-                        'amount': process.env.AMOUNT_SBD + ' SBD',
-                        'from': process.env.MULTISIG_ACCOUNT,
-                        'memo': '',
-                        'to': process.env.SEND_TO
-                    }
-                ]
-            ]
-        };
-
-        let transaction = {
-            ref_block_num,
-            ref_block_prefix,
-            expiration: new Date(Date.now() + expireTime).toISOString().slice(0, -5),
-            operations: transactionData.operations,
-            extensions: []
-        };
-
+        // create transaction with necessary operations
+        let transaction = await getBlankTransaction();
+        transaction.operations = await getOperations();
         const signedTransaction = steem.auth.signTransaction(transaction, [process.env.ACTIVE_KEY]);
 
-        let json_metadata = await getJsonMetadata(username);
-        json_metadata.mtx = JSON.stringify(signedTransaction)
+        // add signed transaction to account metadata
+        let json_metadata = await getJsonMetadata(accountName);
+        json_metadata[metadataKey] = JSON.stringify(signedTransaction)
 
-        let ops = [];
-        ops.push(
-            [
-                'account_update2',
-                {
-                    account: username,
-                    json_metadata: "",
-                    posting_json_metadata: JSON.stringify(json_metadata)
-                },
-            ])
+        // update account metadata with signed transaction
+        const ops = [
+            getAccountUpdateOperation(accountName, JSON.stringify(json_metadata))
+        ];
         let finalTx = { operations: ops, extensions: [] };
         const tx = await sendTransaction(finalTx, { posting: process.env.POSTING_KEY })
+        
         resolve(tx)
     })
 }
 
-async function getCreatePublishTx(context) {
+async function signPublishTx(context) {
     return new Promise(async (resolve, reject) => {
 
         try {
-            const { accountName } = context;
-            let json_metadata = await getJsonMetadata(accountName);
+            const { accountName, metadataKey } = context;
+            
+            // get transaction from previous or second last account and sign it
             const previousTx = await getPreviousTransaction(context);
             const signedTransaction = steem.auth.signTransaction(previousTx, [process.env.ACTIVE_KEY]);
-            json_metadata.mtx = JSON.stringify(signedTransaction)
-            let ops = [];
-            ops.push(
-                [
-                    'account_update2',
-                    {
-                        account: accountName,
-                        json_metadata: "",
-                        posting_json_metadata: JSON.stringify(json_metadata)
-                    },
-                ])
+
+            // add signed transaction to account metadata
+            let json_metadata = await getJsonMetadata(accountName);
+            json_metadata[metadataKey] = JSON.stringify(signedTransaction)
+            
+            // update account metadata with signed transaction
+            const ops = [
+                getAccountUpdateOperation(accountName, JSON.stringify(json_metadata))
+            ];    
             let finalTx = { operations: ops, extensions: [] };
             const tx = await sendTransaction(finalTx, { posting: process.env.POSTING_KEY })
+            
             resolve(tx)
         } catch (error) {
             reject(error)
@@ -189,13 +258,17 @@ async function getCreatePublishTx(context) {
     })
 }
 
-async function sendTx(context) {
+async function signSendTx(context) {
     return new Promise(async (resolve, reject) => {
 
         try {
+            // get transaction from previous or second last account and sign it
             const previousTx = await getPreviousTransaction(context);
             const signedTransaction = steem.auth.signTransaction(previousTx, [process.env.ACTIVE_KEY]);
+            
+            // broadcast signed transaction
             const tx = await broadcastTransaction(signedTransaction)
+            
             resolve(tx)
         } catch (error) {
             reject(error)
@@ -203,4 +276,4 @@ async function sendTx(context) {
     })
 }
 
-module.exports = { createPublishTx, getCreatePublishTx, sendTx }
+module.exports = { createPublishTx, signPublishTx, signSendTx }

--- a/utils.js
+++ b/utils.js
@@ -223,7 +223,7 @@ function getTransferOperation(amount, unit, from, to, memo = '') {
     return [
         'transfer',
         {
-            'amount': amount + ' ' + unit.toUpperCase(),
+            'amount': amount.toFixed(3) + ' ' + unit.toUpperCase(),
             'from': from,
             'memo': memo,
             'to': to
@@ -241,8 +241,8 @@ function getOrderOperation(account, sbdToSell, steemToBuy) {
         {
             'owner': account,
             'orderid': orderId,
-            'amount_to_sell': sbdToSell + ' SBD',
-            'min_to_receive': steemToBuy + ' STEEM',
+            'amount_to_sell': sbdToSell.toFixed(3) + ' SBD',
+            'min_to_receive': steemToBuy.toFixed(3) + ' STEEM',
             'fill_or_kill': false,
             'expiration': new Date(Date.now() + expireTime).toISOString().slice(0, -5)
         }

--- a/utils.js
+++ b/utils.js
@@ -321,7 +321,6 @@ function createPublishTx(context) {
             // add signed transaction to account metadata
             let json_metadata = await getJsonMetadata(accountName);
             json_metadata[metadataKey] = JSON.stringify(signedTransaction)
-            delete json_metadata['mtx']
 
             // update account metadata with signed transaction
             const ops = [

--- a/utils.js
+++ b/utils.js
@@ -126,8 +126,7 @@ function transactionIsValid(operations) {
         case 'transfer':
             // allowed are only transfer operations
             // and to accounts specified in allowedAccounts
-            //const allowedAccounts = [process.env.SEND_TO, "steem.dao"];
-            const allowedAccounts = [process.env.SEND_TO, "moecki.tests"]; // TODO for testing
+            const allowedAccounts = [process.env.SEND_TO, "steem.dao"];
             return operations.every(operation => 
                 operation[0] === 'transfer' &&
                 allowedAccounts.includes(operation[1].to)
@@ -136,8 +135,7 @@ function transactionIsValid(operations) {
             // allowed are only transfer to null and limit_order_create operations
             return operations.every(operation => 
                 operation[0] === 'limit_order_create' ||
-                // (operation[0] === 'transfer' && operation[1].to === "null")
-                (operation[0] === 'transfer' && operation[1].to === "moecki.tests") // TODO for testing
+                (operation[0] === 'transfer' && operation[1].to === "null")
             );
     }
 }
@@ -169,19 +167,12 @@ async function getOperations() {
                 // transfer remaining amounts back to dao
                 const sbdToDao = sbdBalance - sbdToMarket;
                 if (sbdToDao > 0) {                    
-                    // ops.push(getTransferOperation(
-                    //     sbdToDao, 
-                    //     'SBD', 
-                    //     process.env.MULTISIG_ACCOUNT, 
-                    //     'steem.dao',
-                    //     'DAO amount not used for selling and burning')
-                    // )
                     ops.push(getTransferOperation(
-                        0.001, 
+                        sbdToDao, 
                         'SBD', 
                         process.env.MULTISIG_ACCOUNT, 
-                        'moecki.tests',
-                        'TEST: DAO amount not used for selling and burning (prod. receiver: @steem.dao)') // TODO for testing
+                        'steem.dao',
+                        'DAO amount not used for selling and burning')
                     )
                 }
             }
@@ -190,19 +181,12 @@ async function getOperations() {
             // transfer all STEEM to null
             const steemBalance = await getBalance(process.env.MULTISIG_ACCOUNT, 'STEEM');
             if (steemBalance > 0) {
-                // ops.push(getTransferOperation(
-                    //     steemBalance,
-                    //     'STEEM',
-                    //     process.env.MULTISIG_ACCOUNT,
-                    //     'null',
-                    //     'Burning STEEM from sold DAO funds')
-                    // )
                 ops.push(getTransferOperation(
                     steemBalance,
                     'STEEM',
                     process.env.MULTISIG_ACCOUNT,
-                    'moecki.tests',
-                    'TEST: Burning STEEM from sold SBD (prod. receiver: @null)') // TODO for testing
+                    'null',
+                    'Burning STEEM from sold DAO funds')
                 )
             }
             if (sbdBalance > 0) {
@@ -213,11 +197,6 @@ async function getOperations() {
                     sbdBalance,
                     steemToBuy)
                 )
-                // ops.push(getOrderOperation(
-                //     process.env.MULTISIG_ACCOUNT,
-                //     0.001,
-                //     steemToBuy) // TODO for testing
-                // )
             }
             break;
     }
@@ -256,7 +235,7 @@ function getTransferOperation(amount, unit, from, to, memo = '') {
 function getOrderOperation(account, sbdToSell, steemToBuy) {
     // create unique order id from timestamp
     const orderId = Math.floor(Date.now() / 1000);
-    const expireTime = 1000 * 120; // TODO without test 1000*3000
+    const expireTime = 1000 * 3000;
     return [
         'limit_order_create',
         {

--- a/utils.js
+++ b/utils.js
@@ -198,6 +198,7 @@ async function getOperations() {
                     'DAO amount not used for selling and burning') // TODO for testing
                 )
             }
+            break;
         case 'burn':
             // transfer all STEEM to null
             const steemBalance = await getBalance(process.env.MULTISIG_ACCOUNT, 'STEEM');
@@ -231,6 +232,7 @@ async function getOperations() {
                     steemToBuy) // TODO for testing
                 )
             }
+            break;
     }
     if (ops.length === 0) {
         throw new Error('No operations generated (sbd and steem balance is 0)');
@@ -319,6 +321,7 @@ function createPublishTx(context) {
             // add signed transaction to account metadata
             let json_metadata = await getJsonMetadata(accountName);
             json_metadata[metadataKey] = JSON.stringify(signedTransaction)
+            delete json_metadata['mtx']
 
             // update account metadata with signed transaction
             const ops = [

--- a/utils.js
+++ b/utils.js
@@ -183,20 +183,22 @@ async function getOperations() {
                 )
                 // transfer remaining amounts back to dao
                 const sbdToDao = sbdBalance - sbdToMarket;
-                // ops.push(getTransferOperation(
-                //     sbdToDao, 
-                //     'SBD', 
-                //     process.env.MULTISIG_ACCOUNT, 
-                //     'steem.dao',
-                //     'DAO amount not used for selling and burning')
-                // )
-                ops.push(getTransferOperation(
-                    0.001, 
-                    'SBD', 
-                    process.env.MULTISIG_ACCOUNT, 
-                    'moecki.tests',
-                    'DAO amount not used for selling and burning') // TODO for testing
-                )
+                if (sbdToDao > 0) {                    
+                    // ops.push(getTransferOperation(
+                    //     sbdToDao, 
+                    //     'SBD', 
+                    //     process.env.MULTISIG_ACCOUNT, 
+                    //     'steem.dao',
+                    //     'DAO amount not used for selling and burning')
+                    // )
+                    ops.push(getTransferOperation(
+                        0.001, 
+                        'SBD', 
+                        process.env.MULTISIG_ACCOUNT, 
+                        'moecki.tests',
+                        'TEST: DAO amount not used for selling and burning (prod. receiver: @steem.dao)') // TODO for testing
+                    )
+                }
             }
             break;
         case 'burn':
@@ -215,7 +217,7 @@ async function getOperations() {
                     'STEEM',
                     process.env.MULTISIG_ACCOUNT,
                     'moecki.tests',
-                    'Burning STEEM from sold SBD') // TODO for testing
+                    'TEST: Burning STEEM from sold SBD (prod. receiver: @null)') // TODO for testing
                 )
             }
             if (sbdBalance > 0) {

--- a/utils.js
+++ b/utils.js
@@ -222,17 +222,17 @@ async function getOperations() {
             }
             if (sbdBalance > 0) {
                 // sell all SBD on internal market
-                const steemToBuy = await getSteemToBuy(0.001);
-                // ops.push(getOrderOperation(
-                //     process.env.MULTISIG_ACCOUNT,
-                //     sbdBalance,
-                //     steemToBuy)
-                // )
+                const steemToBuy = await getSteemToBuy(sbdBalance);
                 ops.push(getOrderOperation(
                     process.env.MULTISIG_ACCOUNT,
-                    0.001,
-                    steemToBuy) // TODO for testing
+                    sbdBalance,
+                    steemToBuy)
                 )
+                // ops.push(getOrderOperation(
+                //     process.env.MULTISIG_ACCOUNT,
+                //     0.001,
+                //     steemToBuy) // TODO for testing
+                // )
             }
             break;
     }


### PR DESCRIPTION
This pull request implements the following processes:

1. Differentiation of the processes based on the parameters in the .env file.
2. The `transfer` process transfers SBD from a multisig account. The `burn` process sells the received SBD on the internal market and transfers the purchased STEEM to @null (burning).
3. The necessary operations are stored as a transaction in the `json_metadata` of the multisig account.
4. The signer accounts (a maximum of 3 signer accounts are possible) load the signed transaction from the previous account, sign it and save the signed transaction in their own `json_metadata` for the next signer.
5. The last signer account loads, signs and sends the signed transaction to the blockchain.
6. A signer account will be skipped in case of failure.
